### PR TITLE
Change run_id endpoint to run

### DIFF
--- a/piperci_gman/app.py
+++ b/piperci_gman/app.py
@@ -23,8 +23,8 @@ api.add_resource(GMan,
                  '/task',
                  '/task/<uuid:task_id>',
                  '/task/<uuid:task_id>/<events>',
-                 '/task/run_id/<string:run_id>',
-                 '/task/run_id/<string:run_id>/<events>',
+                 '/run/<string:run_id>',
+                 '/run/<string:run_id>/<events>',
                  '/thread/<uuid:thread_id>',
                  '/thread/<uuid:thread_id>/<events>'
                  )

--- a/tests/test_gman.py
+++ b/tests/test_gman.py
@@ -526,14 +526,14 @@ def test_head_thread_events(api, client, testthread):
     assert int(resp.headers['x-gman-tasks-pending']) == 2
 
 
-def test_head_rund_id_events(api, client, testthread):
+def test_head_run_id_events(api, client, testthread):
     resp = client.get(f'/task/{testthread}')
     assert resp.status_code == 200
     assert 'run_id' in resp.json
 
     run_id = resp.json['run_id']
 
-    resp = client.head(f'/task/run_id/{run_id}')
+    resp = client.head(f'/run/{run_id}')
 
     assert resp.status_code == 200
     assert 'x-gman-tasks-running' in resp.headers


### PR DESCRIPTION
This ensures that the endpoint names follow a similiar convention.
/thread
/run
/task